### PR TITLE
Fix camera picture recreating sessions for switch camera

### DIFF
--- a/android/src/main/java/com/apparence/camerawesome/CameraPicture.java
+++ b/android/src/main/java/com/apparence/camerawesome/CameraPicture.java
@@ -36,7 +36,7 @@ public class CameraPicture implements CameraSession.OnCaptureSession {
 
     private final CameraSession mCameraSession;
 
-    private final CameraCharacteristicsModel mCameraCharacteristics;
+    private CameraCharacteristicsModel mCameraCharacteristics;
 
     private CameraDevice mCameraDevice;
 
@@ -70,6 +70,7 @@ public class CameraPicture implements CameraSession.OnCaptureSession {
     }
 
     public void refresh() {
+        setAutoFocus(this.autoFocus);
         pictureImageReader = ImageReader.newInstance(size.getWidth(), size.getHeight(), ImageFormat.JPEG, 2);
         mCameraSession.addPictureSurface(pictureImageReader.getSurface());
     }
@@ -87,15 +88,14 @@ public class CameraPicture implements CameraSession.OnCaptureSession {
         this.mCameraDevice = cameraDevice;
         this.orientation = orientation;
         if (file.exists()) {
-            //FIXME throw here
+            Log.e(TAG, "takePicture : PATH NOT FOUND");
             return;
         }
         if(size == null) {
-            //FIXME throw here
+            Log.e(TAG, "takePicture : NO SIZE SET");
             return;
         }
         if(mCameraSession.getCaptureSession() == null) {
-            //FIXME throw here
             Log.e(TAG, "takePicture: mCameraSession.getCaptureSession() is null");
             return;
         }
@@ -123,6 +123,10 @@ public class CameraPicture implements CameraSession.OnCaptureSession {
             return;
         }
         this.flashMode = flashMode;
+    }
+
+    public void setCameraCharacteristics(CameraCharacteristicsModel mCameraCharacteristics) {
+        this.mCameraCharacteristics = mCameraCharacteristics;
     }
 
     public void setAutoFocus(boolean autoFocus) {

--- a/android/src/main/java/com/apparence/camerawesome/CameraSession.java
+++ b/android/src/main/java/com/apparence/camerawesome/CameraSession.java
@@ -72,20 +72,10 @@ public class CameraSession {
 
     public void addPreviewSurface(Surface surface) {
         this.surfaces.put(PREVIEW_SURFACE_KEY, surface);
-        // todo if session is active recreate session
     }
 
     public void addPictureSurface(Surface surface) {
         this.surfaces.put(PHOTO_SURFACE_KEY, surface);
-        // if session is active recreate session
-        if(mCaptureSession != null) {
-            try {
-                mCaptureSession.abortCaptures();
-                this.createCameraCaptureSession(cameraDevice);
-            } catch (CameraAccessException e) {
-                Log.e(TAG, "addPictureSurface: failed to recreate camera session", e);
-            }
-        }
     }
 
     public void clearSurface() {

--- a/android/src/main/java/com/apparence/camerawesome/CameraStateManager.java
+++ b/android/src/main/java/com/apparence/camerawesome/CameraStateManager.java
@@ -82,9 +82,10 @@ public class CameraStateManager extends CameraDevice.StateCallback {
             return;
         }
         stopCamera();
+        mCameraSession.clearSurface();
+        mCameraPicture.setCameraCharacteristics(characteristicsModel);
         mCameraPreview.setmCameraCharacteristics(characteristicsModel);
         startCamera(cameraId);
-        mCameraPicture.refresh();
         Log.d(TAG, "switchCamera: finished");
     }
 
@@ -129,7 +130,8 @@ public class CameraStateManager extends CameraDevice.StateCallback {
         this.mCameraDevice = camera;
         // init cameraPreview
         try {
-            this.mCameraPreview.createCameraPreviewSession(mCameraDevice);
+            mCameraPicture.refresh();
+            mCameraPreview.createCameraPreviewSession(mCameraDevice);
         } catch (CameraAccessException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Fix camera error on session closed while switching camera. 
CameraPicture should not call to a recreate session. This is CameraStateManager responsability. 
Also clear surface must be called before recreating session as old ones won't be usable anymore. 