### PR TITLE
fix camera called stop in onDetachedFromActivity even if not started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.2+1
+- [Android] onDetachedFromActivity : fix stopping the camera should be only done if camera has been started
+## 0.1.2
+- [Android] get luminosity level from device
+- [Android] apply brightness correction
 ## 0.1.1+1
 - [android] fix release onOpenListener after emit result to Flutter platform
 ## 0.1.1

--- a/android/src/main/java/com/apparence/camerawesome/CamerawesomePlugin.java
+++ b/android/src/main/java/com/apparence/camerawesome/CamerawesomePlugin.java
@@ -493,7 +493,6 @@ public class CamerawesomePlugin implements FlutterPlugin, MethodCallHandler, Act
 
   @Override
   public void onAttachedToActivity(@NonNull ActivityPluginBinding binding) {
-    Log.d(TAG, "onAttachedToActivity: ");
     this.pluginActivity = binding.getActivity();
     binding.addRequestPermissionsResultListener(this.cameraPermissions);
     if (this.mCameraPreview != null)
@@ -502,14 +501,12 @@ public class CamerawesomePlugin implements FlutterPlugin, MethodCallHandler, Act
 
   @Override
   public void onDetachedFromActivityForConfigChanges() {
-    Log.d(TAG, "onDetachedFromActivityForConfigChanges: ");
     this.pluginActivity = null;
     this.mCameraPreview.setMainHandler(null);
   }
 
   @Override
   public void onReattachedToActivityForConfigChanges(@NonNull ActivityPluginBinding binding) {
-    Log.d(TAG, "onReattachedToActivityForConfigChanges: ");
     this.pluginActivity = binding.getActivity();
     binding.addRequestPermissionsResultListener(this.cameraPermissions);
     this.mCameraPreview.setMainHandler(new Handler(pluginActivity.getMainLooper()));
@@ -517,9 +514,13 @@ public class CamerawesomePlugin implements FlutterPlugin, MethodCallHandler, Act
 
   @Override
   public void onDetachedFromActivity() {
-    Log.d(TAG, "onDetachedFromActivity: ");
     this.pluginActivity = null;
-    this.mCameraStateManager.stopCamera();
-    this.mCameraPreview.setMainHandler(null);
+    if(this.mCameraStateManager != null) {
+      this.mCameraStateManager.stopCamera();
+      this.mCameraStateManager = null;
+    }
+    if(this.mCameraPreview != null) {
+      this.mCameraPreview.setMainHandler(null);
+    }
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -49,7 +49,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.1+1"
+    version: "0.1.2+1"
   characters:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: camerawesome
 description: An open source camera plugin by the community for the community
-version: 0.1.1+1
+version: 0.1.2+1
 homepage: https://Apparence.io
 repository: https://github.com/Apparence-io/camera_awesome
 


### PR DESCRIPTION
## Description

[Android] onDetachedFromActivity : fix stopping the camera should be only done if camera has been started