### PR TITLE
Do not close eventsink on receiving permissions request result

### DIFF
--- a/android/src/main/java/com/apparence/camerawesome/CameraPermissions.java
+++ b/android/src/main/java/com/apparence/camerawesome/CameraPermissions.java
@@ -2,6 +2,7 @@ package com.apparence.camerawesome;
 
 import android.app.Activity;
 import android.content.pm.PackageManager;
+import android.util.Log;
 
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
@@ -17,6 +18,8 @@ import static android.Manifest.permission.CAMERA;
 import static android.Manifest.permission.WRITE_EXTERNAL_STORAGE;
 
 public class CameraPermissions implements EventChannel.StreamHandler, PluginRegistry.RequestPermissionsResultListener {
+
+    private static final String TAG = CameraPermissions.class.getName();
 
     private static  final String[] permissions = new String[]{ CAMERA, WRITE_EXTERNAL_STORAGE };
 
@@ -67,8 +70,10 @@ public class CameraPermissions implements EventChannel.StreamHandler, PluginRegi
 
     @Override
     public void onCancel(Object arguments) {
-        this.events.endOfStream();
-        this.events = null;
+        if(this.events != null) {
+            this.events.endOfStream();
+            this.events = null;
+        }
     }
 
     // ---------------------------------------------
@@ -86,8 +91,10 @@ public class CameraPermissions implements EventChannel.StreamHandler, PluginRegi
         }
         if(this.events != null) {
             this.events.success(permissionGranted);
-            this.events.endOfStream();
+        } else {
+            Log.d(TAG, "_onRequestPermissionsResult: received permissions but the EventSink is closed");
         }
+
         return permissionGranted;
     }
 }

--- a/android/src/main/java/com/apparence/camerawesome/CamerawesomePlugin.java
+++ b/android/src/main/java/com/apparence/camerawesome/CamerawesomePlugin.java
@@ -531,6 +531,9 @@ public class CamerawesomePlugin implements FlutterPlugin, MethodCallHandler, Act
   @Override
   public void onDetachedFromActivity() {
     this.pluginActivity = null;
+    if (this.cameraPermissions != null) {
+      this.cameraPermissions.onCancel(null);
+    }
     if(this.mCameraStateManager != null) {
       this.mCameraStateManager.stopCamera();
       this.mCameraStateManager = null;


### PR DESCRIPTION
## Description

Currently the following permissions flow breaks in release 0.2.1+2 and current master:
- open camera
- deny permissions
- change permissions in the App settings
- going back to the app
- camera is stuck (infinite spinner). The callbacks `onPermissionsResult` and `onCameraStarted` are never called.

Debugging this problem showed that the events sink is closed with the first "permission denied" message passed back from Java to dart. Hence, the second event, which would grant the permission, is received via the `onRequestPermissionsResult` callback, but it can't be sent through a closed channel.

This is a fairly naive fix and I am sure that line was there for a reason, but I couldn't find it and would be happy about some guidance. My tests looked promising..


## Checklist

- [x] 📕 I read the [Contributing page](https://github.com/Apparence-io/camera_awesome/blob/master/CONTRIBUTING.md).
- [x] 🤝 I match the actual coding style.
- [x] ✅ I ran ```flutter analyse``` without any issues.

## Breaking Change

- [?] 🛠 My feature contain breaking change.

I've tested it on my device, but I could easily have missed something.


Huge thanks for this library! 