### PR TITLE
Fix/handle others permission results

### DIFF
--- a/android/src/main/java/com/apparence/camerawesome/CameraPermissions.java
+++ b/android/src/main/java/com/apparence/camerawesome/CameraPermissions.java
@@ -10,6 +10,7 @@ import androidx.core.content.ContextCompat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.StringJoiner;
 
 import io.flutter.plugin.common.EventChannel;
 import io.flutter.plugin.common.PluginRegistry;
@@ -47,6 +48,7 @@ public class CameraPermissions implements EventChannel.StreamHandler, PluginRegi
     public void checkAndRequestPermissions(Activity activity) {
         String[] permissionsToAsk = checkPermissions(activity);
         if(permissionsToAsk.length > 0) {
+            Log.d(TAG, "_checkAndRequestPermissions: " + String.join(",", permissionsToAsk));
             ActivityCompat.requestPermissions(
                     activity,
                     permissionsToAsk,
@@ -90,6 +92,7 @@ public class CameraPermissions implements EventChannel.StreamHandler, PluginRegi
             }
         }
         if(this.events != null) {
+            Log.d(TAG, "_onRequestPermissionsResult: granted " + String.join(", ", permissions));
             this.events.success(permissionGranted);
         } else {
             Log.d(TAG, "_onRequestPermissionsResult: received permissions but the EventSink is closed");

--- a/lib/camerapreview.dart
+++ b/lib/camerapreview.dart
@@ -152,7 +152,8 @@ class CameraAwesomeState extends State<CameraAwesome>
     selectedPreviewSize = ValueNotifier(null);
     selectedAndroidPhotoSize = ValueNotifier(null);
     brightnessCorrectionData = PublishSubject();
-    initPlatformState();
+
+    scheduleInitPlatformState();
     super.didChangeDependencies();
   }
 
@@ -184,17 +185,25 @@ class CameraAwesomeState extends State<CameraAwesome>
     super.dispose();
   }
 
-  Future<void> initPlatformState() async {
+  Future<void> scheduleInitPlatformState() async {
+    bool hadPermission = false;
+
     // wait user accept permissions to init widget completely on android
     if (Platform.isAndroid) {
       _permissionStreamSub =
           CamerawesomePlugin.listenPermissionResult().listen((res) {
-        if (res) {
+        if (res && !hadPermission) {
           initPlatformState();
         }
         widget.onPermissionsResult(res);
+        hadPermission = res;
       });
     }
+
+    initPlatformState();
+  }
+
+  Future<void> initPlatformState() async {
     hasPermissions = await CamerawesomePlugin.checkPermissions();
     if (widget.onPermissionsResult != null) {
       widget.onPermissionsResult(hasPermissions);


### PR DESCRIPTION
## Description

Currently, when other processes cause a permission result callback, the `initState` function is called, re-initializing _and_ registering another listener. Some flutter plugins might cause many of these callbacks, leading to more and more (exponentially doubling) listeners and re-initializations. This may lead to weird saturation effects because it is registering too many camera specific listeners.

## Checklist

Before creating any Pull Request, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] 📕 I read the [Contributing page](https://github.com/Apparence-io/camera_awesome/blob/master/CONTRIBUTING.md).
- [x] 🤝 I match the actual coding style.
- [x] ✅ I ran ```flutter analyse``` without any issues.

## Breaking Change

- [x] 🛠 My feature contain breaking change.

I don't think it breaks anything.

