### PR TITLE
Add optional for storage permission on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## BREAKING CHANGE
+- add optional for requesting write storage permission on Android
+- fix error in example pointed that we should init before starting.
+
 ## 0.3.1
 - handle app lifecycle (stop camera on background)
 ## 0.3.0

--- a/android/src/main/java/com/apparence/camerawesome/CameraPermissions.java
+++ b/android/src/main/java/com/apparence/camerawesome/CameraPermissions.java
@@ -9,6 +9,7 @@ import androidx.core.content.ContextCompat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.StringJoiner;
 
@@ -22,7 +23,7 @@ public class CameraPermissions implements EventChannel.StreamHandler, PluginRegi
 
     private static final String TAG = CameraPermissions.class.getName();
 
-    private static  final String[] permissions = new String[]{ CAMERA, WRITE_EXTERNAL_STORAGE };
+    private static final List<String> permissions = new ArrayList<String>();
 
     private static final int PERMISSIONS_MULTIPLE_REQUEST = 5;
 
@@ -31,9 +32,16 @@ public class CameraPermissions implements EventChannel.StreamHandler, PluginRegi
     private EventChannel.EventSink events;
 
 
-    public String[] checkPermissions(Activity activity) {
+
+    public String[] checkPermissions(Activity activity, boolean ignoreExternalStorage) {
         if(activity == null) {
             throw new RuntimeException("NULL_ACTIVITY");
+        }
+        if (permissions.isEmpty()) {
+            permissions.add(CAMERA);
+            if (!ignoreExternalStorage) {
+                permissions.add(WRITE_EXTERNAL_STORAGE);
+            }
         }
         List<String> permissionsToAsk = new ArrayList<>();
         for(String permission : permissions) {
@@ -45,8 +53,8 @@ public class CameraPermissions implements EventChannel.StreamHandler, PluginRegi
         return permissionsToAsk.toArray(new String[0]);
     }
 
-    public void checkAndRequestPermissions(Activity activity) {
-        String[] permissionsToAsk = checkPermissions(activity);
+    public void checkAndRequestPermissions(Activity activity, boolean ignoreExternalStorage) {
+        String[] permissionsToAsk = checkPermissions(activity, ignoreExternalStorage);
         if(permissionsToAsk.length > 0) {
             Log.d(TAG, "_checkAndRequestPermissions: " + String.join(",", permissionsToAsk));
             ActivityCompat.requestPermissions(

--- a/android/src/main/java/com/apparence/camerawesome/CamerawesomePlugin.java
+++ b/android/src/main/java/com/apparence/camerawesome/CamerawesomePlugin.java
@@ -205,7 +205,11 @@ public class CamerawesomePlugin implements FlutterPlugin, MethodCallHandler, Act
   private void _handleCheckPermissions(MethodCall call, Result result) {
     try {
       assert(pluginActivity !=null);
-      String[] missingPermissions = cameraPermissions.checkPermissions(pluginActivity);
+      boolean ignoreExternalStorage = false;
+      if (call.argument("ignoreExternalStorage") != null) {
+        ignoreExternalStorage = call.argument("ignoreExternalStorage");
+      }
+      String[] missingPermissions = cameraPermissions.checkPermissions(pluginActivity, ignoreExternalStorage);
       if(missingPermissions.length == 0) {
         result.success(new ArrayList<>());
       } else {
@@ -218,7 +222,11 @@ public class CamerawesomePlugin implements FlutterPlugin, MethodCallHandler, Act
   }
 
   private void _handleRequestPermissions(MethodCall call, Result result) {
-    cameraPermissions.checkAndRequestPermissions(pluginActivity);
+    boolean ignoreExternalStorage = false;
+    if (call.argument("ignoreExternalStorage") != null) {
+      ignoreExternalStorage = call.argument("ignoreExternalStorage");
+    }
+    cameraPermissions.checkAndRequestPermissions(pluginActivity, ignoreExternalStorage);
   }
 
   private void _handleSetup(MethodCall call, Result result) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -347,6 +347,7 @@ class _MyAppState extends State<MyApp> with TickerProviderStateMixin {
       right: 0,
       child: Center(
         child: CameraAwesome(
+          ignoreExternalStorage: true,
           onPermissionsResult: _onPermissionsResult,
           selectDefaultSize: (availableSizes) {
             this._availableSizes = availableSizes;

--- a/lib/camerawesome_plugin.dart
+++ b/lib/camerawesome_plugin.dart
@@ -47,8 +47,8 @@ class CamerawesomePlugin {
 
   static CameraState currentState = CameraState.STOPPED;
 
-  static Future<List<String>> checkAndroidPermissions() => _channel
-      .invokeMethod("checkPermissions")
+  static Future<List<String>> checkAndroidPermissions({bool ignoreExternalStorage = false}) => _channel
+      .invokeMethod("checkPermissions", <String, dynamic>{'ignoreExternalStorage': ignoreExternalStorage})
       .then((res) => res.cast<String>());
 
   static Future<bool?> checkiOSPermissions() =>
@@ -285,11 +285,12 @@ class CamerawesomePlugin {
   // UTILITY METHODS
   // ---------------------------------------------------
 
-  static Future<bool?> checkPermissions() async {
+  static Future<bool?> checkPermissions({bool ignoreExternalStorage = false}) async {
     try {
       if (Platform.isAndroid) {
         var missingPermissions =
-            await CamerawesomePlugin.checkAndroidPermissions();
+            await CamerawesomePlugin.checkAndroidPermissions(ignoreExternalStorage: ignoreExternalStorage);
+        print('Hello $ignoreExternalStorage : $missingPermissions');
         if (missingPermissions.length > 0) {
           return CamerawesomePlugin.requestPermissions()
               .then((value) => value == null);


### PR DESCRIPTION
## Description

Sometimes, developers don't need require WRITE STORAGE in android in their purpose. So it will a bit annoying to user when the storage permission was asked, so I hope it should have an option to ignore STORAGE permission

## Checklist

Before creating any Pull Request, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] 📕 I read the [Contributing page](https://github.com/Apparence-io/camera_awesome/blob/master/CONTRIBUTING.md).
- [x] 🤝 I match the actual coding style.
- [x] ✅ I ran ```flutter analyse``` without any issues.

## Breaking Change

- [x] 🛠 My feature contain breaking change.

*If your feature break something, please detail it*