### PR TITLE
fix '!' has type 'WidgetsBinding' | Flutter 3 

### DIFF
--- a/lib/camerapreview.dart
+++ b/lib/camerapreview.dart
@@ -137,7 +137,7 @@ class CameraAwesomeState extends State<CameraAwesome> with WidgetsBindingObserve
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance!.addObserver(this);
+    WidgetsBinding.instance.addObserver(this);
   }
 
   @override
@@ -180,7 +180,7 @@ class CameraAwesomeState extends State<CameraAwesome> with WidgetsBindingObserve
   void dispose() {
     started = false;
     stopping = true;
-    WidgetsBinding.instance!.removeObserver(this);
+    WidgetsBinding.instance.removeObserver(this);
     CamerawesomePlugin.stop();
     selectedAndroidPhotoSize!.dispose();
     selectedPreviewSize!.dispose();


### PR DESCRIPTION
## Description

Fix
```
/lib/camerapreview.dart:146:20: Warning: Operand of null-aware operation '!' has type 'WidgetsBinding' 
which excludes null.
``` 
problems in flutter 3


## Checklist

Before creating any Pull Request, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [ ] 📕 I read the [Contributing page](https://github.com/Apparence-io/camera_awesome/blob/master/CONTRIBUTING.md).
- [X] 🤝 I match the actual coding style.
- [X] ✅ I ran ```flutter analyse``` without any issues.

## Breaking Change

- [ ] 🛠 My feature contain breaking change.

*If your feature break something, please detail it*