### PR TITLE
Turn stopRecording into a Future, example usage for video preview

### DIFF
--- a/android/src/main/kotlin/com/apparence/camerawesome/cameraX/Pigeon.kt
+++ b/android/src/main/kotlin/com/apparence/camerawesome/cameraX/Pigeon.kt
@@ -105,7 +105,7 @@ interface CameraInterface {
   fun recordVideo(path: String)
   fun pauseVideoRecording()
   fun resumeVideoRecording()
-  fun stopRecordingVideo()
+  fun stopRecordingVideo(callback: (Boolean) -> Unit)
   fun start(): Boolean
   fun stop(): Boolean
   fun setFlashMode(mode: String)
@@ -288,12 +288,13 @@ val codec: MessageCodec<Any?> by lazy {
           channel.setMessageHandler { _, reply ->
             val wrapped = hashMapOf<String, Any?>()
             try {
-              api.stopRecordingVideo()
-              wrapped["result"] = null
+              api.stopRecordingVideo() {
+                reply.reply(wrapResult(it))
+              }
             } catch (exception: Error) {
               wrapped["error"] = wrapError(exception)
+              reply.reply(wrapped)
             }
-            reply.reply(wrapped)
           }
         } else {
           channel.setMessageHandler(null)

--- a/docs/getting_started/custom-ui.mdx
+++ b/docs/getting_started/custom-ui.mdx
@@ -30,6 +30,8 @@ CameraAwesomeBuilder.custom(
 )
 ```
 
+You can find more examples on the `example` folder.
+
 ### Properties
 
 | Method                           | Comment | 

--- a/docs/widgets/awesome_buttons.mdx
+++ b/docs/widgets/awesome_buttons.mdx
@@ -10,8 +10,6 @@ Yet, if some of our buttons suit your needs, feel free to use them!
 
 Shows a clickable preview of a media captured using CamerAwesome.
 
-Note: video preview is not implemented yet.
-
 _This widget rotates when the camera rotates._
 
 Below example shows how to show the last captured media using `AwesomeMediaPreview`.
@@ -33,6 +31,16 @@ StreamBuilder<MediaCapture?>(
   },
 )
 ```
+
+Note: video preview is not implemented in this widget since it would imply a dependency to other packages.
+
+
+You can find an alternative widget that auto plays the last video recorded in the `example` project at `widgets/custom_media_preview.dart`.
+
+It uses the `video_player` package under the hood.
+
+See its usage in `custom_ui_example_3.dart`.
+
 
 ### AwesomeFlashButton
 

--- a/example/lib/custom_ui_example_3.dart
+++ b/example/lib/custom_ui_example_3.dart
@@ -1,0 +1,95 @@
+import 'dart:io';
+
+import 'package:better_open_file/better_open_file.dart';
+import 'package:camerawesome/camerawesome_plugin.dart';
+import 'package:flutter/material.dart';
+import 'package:path_provider/path_provider.dart';
+
+import 'widgets/custom_media_preview.dart';
+
+class CustomUiExample3 extends StatelessWidget {
+  const CustomUiExample3({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: CameraAwesomeBuilder.custom(
+        builder: (cameraState) {
+          return cameraState.when(
+            onPreparingCamera: (state) =>
+                const Center(child: CircularProgressIndicator()),
+            onPhotoMode: (state) => TakePhotoUI(state),
+            onVideoMode: (state) => RecordVideoUI(state, recording: false),
+            onVideoRecordingMode: (state) =>
+                RecordVideoUI(state, recording: true),
+          );
+        },
+        saveConfig: SaveConfig.video(
+          pathBuilder: () => _path(CaptureMode.video),
+        ),
+      ),
+    );
+  }
+
+  Future<String> _path(CaptureMode captureMode) async {
+    final Directory extDir = await getTemporaryDirectory();
+    final testDir =
+        await Directory('${extDir.path}/test').create(recursive: true);
+    final String fileExtension =
+        captureMode == CaptureMode.photo ? 'jpg' : 'mp4';
+    final String filePath =
+        '${testDir.path}/${DateTime.now().millisecondsSinceEpoch}.$fileExtension';
+    return filePath;
+  }
+}
+
+class TakePhotoUI extends StatelessWidget {
+  final PhotoCameraState state;
+
+  const TakePhotoUI(this.state, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container();
+  }
+}
+
+class RecordVideoUI extends StatelessWidget {
+  final CameraState state;
+  final bool recording;
+
+  const RecordVideoUI(this.state, {super.key, required this.recording});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        const Spacer(),
+        Padding(
+          padding: const EdgeInsets.only(bottom: 20, left: 20, right: 20),
+          child: Row(
+            children: [
+              AwesomeCaptureButton(state: state),
+              const Spacer(),
+              StreamBuilder(
+                stream: state.captureState$,
+                builder: (_, snapshot) {
+                  return SizedBox(
+                    width: 100,
+                    height: 100,
+                    child: CustomMediaPreview(
+                      mediaCapture: snapshot.data,
+                      onMediaTap: (mediaCapture) {
+                        OpenFile.open(mediaCapture.filePath);
+                      },
+                    ),
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/example/lib/widgets/custom_media_preview.dart
+++ b/example/lib/widgets/custom_media_preview.dart
@@ -1,0 +1,84 @@
+import 'dart:io';
+
+import 'package:camera_app/widgets/mini_video_player.dart';
+import 'package:camerawesome/camerawesome_plugin.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class CustomMediaPreview extends StatelessWidget {
+  final MediaCapture? mediaCapture;
+  final OnMediaTap onMediaTap;
+
+  const CustomMediaPreview({
+    super.key,
+    required this.mediaCapture,
+    required this.onMediaTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AwesomeOrientedWidget(
+      child: AspectRatio(
+        aspectRatio: 1,
+        child: Container(
+          decoration: BoxDecoration(
+            color: Colors.white10,
+            shape: BoxShape.circle,
+            border: Border.all(
+              color: Colors.white38,
+              width: 2,
+            ),
+          ),
+          child: ClipOval(
+            child: Material(
+              color: Colors.transparent,
+              child: InkWell(
+                onTap: mediaCapture != null && onMediaTap != null
+                    ? () => onMediaTap!(mediaCapture!)
+                    : null,
+                child: _buildMedia(mediaCapture),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMedia(MediaCapture? mediaCapture) {
+    switch (mediaCapture?.status) {
+      case MediaCaptureStatus.capturing:
+        return Center(
+          child: Padding(
+            padding: const EdgeInsets.all(8),
+            child: Platform.isIOS
+                ? const CupertinoActivityIndicator()
+                : const CircularProgressIndicator(),
+          ),
+        );
+      case MediaCaptureStatus.success:
+        if (mediaCapture!.isPicture) {
+          return Ink.image(
+            fit: BoxFit.cover,
+            image: ResizeImage(
+              FileImage(
+                File(mediaCapture.filePath),
+              ),
+              width: 300,
+            ),
+          );
+        } else {
+          return Ink(
+            child: MiniVideoPlayer(filePath: mediaCapture.filePath),
+          );
+        }
+      case MediaCaptureStatus.failure:
+        return const Icon(Icons.error);
+      case null:
+        return const SizedBox(
+          width: 32,
+          height: 32,
+        );
+    }
+  }
+}

--- a/example/lib/widgets/mini_video_player.dart
+++ b/example/lib/widgets/mini_video_player.dart
@@ -1,0 +1,43 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:video_player/video_player.dart';
+
+class MiniVideoPlayer extends StatefulWidget {
+  final String filePath;
+
+  const MiniVideoPlayer({super.key, required this.filePath});
+
+  @override
+  State<StatefulWidget> createState() {
+    return _MiniVideoPlayer();
+  }
+}
+
+class _MiniVideoPlayer extends State<MiniVideoPlayer> {
+  VideoPlayerController? _controller;
+
+  @override
+  void initState() {
+    _controller = VideoPlayerController.file(File(widget.filePath))
+      ..initialize().then((value) => setState(() {
+            _controller?.setLooping(true);
+            _controller?.play();
+          }));
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    _controller?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_controller == null || _controller?.value.isInitialized != true) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    return VideoPlayer(_controller!);
+  }
+}

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -78,6 +78,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.2"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.17.2"
   exif:
     dependency: "direct dev"
     description:
@@ -135,6 +142,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   fuchsia_remote_debug_protocol:
     dependency: transitive
     description: flutter
@@ -182,6 +194,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.0"
+  html:
+    dependency: transitive
+    description:
+      name: html
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.15.1"
   http:
     dependency: transitive
     description:
@@ -208,6 +227,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.4"
   json_annotation:
     dependency: transitive
     description:
@@ -416,6 +442,41 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.2"
+  video_player:
+    dependency: "direct main"
+    description:
+      name: video_player
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.4.10"
+  video_player_android:
+    dependency: transitive
+    description:
+      name: video_player_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.3.10"
+  video_player_avfoundation:
+    dependency: transitive
+    description:
+      name: video_player_avfoundation
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.3.8"
+  video_player_platform_interface:
+    dependency: transitive
+    description:
+      name: video_player_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.1"
+  video_player_web:
+    dependency: transitive
+    description:
+      name: video_player_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.13"
   vm_service:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   google_mlkit_barcode_scanning: ^0.5.0
   google_mlkit_text_recognition: ^0.5.0
   rxdart: ^0.27.7
+  video_player: ^2.4.10
 
 dev_dependencies:
   exif: ^3.1.2

--- a/lib/pigeon.dart
+++ b/lib/pigeon.dart
@@ -303,9 +303,10 @@ class CameraInterface {
     }
   }
 
-  Future<void> stopRecordingVideo() async {
+  Future<bool> stopRecordingVideo() async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.CameraInterface.stopRecordingVideo', codec, binaryMessenger: _binaryMessenger);
+        'dev.flutter.pigeon.CameraInterface.stopRecordingVideo', codec,
+        binaryMessenger: _binaryMessenger);
     final Map<Object?, Object?>? replyMap =
         await channel.send(null) as Map<Object?, Object?>?;
     if (replyMap == null) {
@@ -314,14 +315,20 @@ class CameraInterface {
         message: 'Unable to establish connection on channel.',
       );
     } else if (replyMap['error'] != null) {
-      final Map<Object?, Object?> error = (replyMap['error'] as Map<Object?, Object?>?)!;
+      final Map<Object?, Object?> error =
+          (replyMap['error'] as Map<Object?, Object?>?)!;
       throw PlatformException(
         code: (error['code'] as String?)!,
         message: error['message'] as String?,
         details: error['details'],
       );
+    } else if (replyMap['result'] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
     } else {
-      return;
+      return (replyMap['result'] as bool?)!;
     }
   }
 

--- a/pigeons/interface.dart
+++ b/pigeons/interface.dart
@@ -47,7 +47,8 @@ abstract class CameraInterface {
 
   void resumeVideoRecording();
 
-  void stopRecordingVideo();
+  @async
+  bool stopRecordingVideo();
 
   bool start();
 


### PR DESCRIPTION
## Description

- Adds ability to await stopRecording() on Android
- Example usage with a video preview launching right after the video has finished recording

This PR fixes #179 on Android

## Checklist

Before creating any Pull Request, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] 📕 I read the [Contributing page](https://github.com/Apparence-io/camera_awesome/blob/master/CONTRIBUTING.md).
- [x] 🤝 I match the actual coding style.
- [ ] ✅ I ran ```flutter analyze``` without any issues.

## Breaking Change

- [ ] 🛠 My feature contain breaking change.

*If your feature break something, please detail it*