### PR TITLE
⚡️ Improve performances on iOS image stream

### DIFF
--- a/android/src/main/kotlin/com/apparence/camerawesome/cameraX/CameraAwesomeX.kt
+++ b/android/src/main/kotlin/com/apparence/camerawesome/cameraX/CameraAwesomeX.kt
@@ -111,7 +111,11 @@ class CameraAwesomeX : CameraInterface, FlutterPlugin, ActivityAware {
         callback(true)
     }
 
-    override fun setupImageAnalysisStream(format: String, width: Long) {
+    override fun setupImageAnalysisStream(
+        format: String,
+        width: Long,
+        maxFramesPerSecond: Double?
+    ) {
         cameraState.apply {
             try {
                 this.imageAnalysisBuilder = ImageAnalysisBuilder.configure(
@@ -123,6 +127,7 @@ class CameraAwesomeX : CameraInterface, FlutterPlugin, ActivityAware {
                         else -> OutputImageFormat.NV21
                     },
                     executor(activity!!), width,
+                    maxFramesPerSecond = maxFramesPerSecond,
                 )
                 updateLifecycle(activity!!)
             } catch (e: Exception) {

--- a/android/src/main/kotlin/com/apparence/camerawesome/cameraX/Pigeon.kt
+++ b/android/src/main/kotlin/com/apparence/camerawesome/cameraX/Pigeon.kt
@@ -124,7 +124,7 @@ interface CameraInterface {
   fun setPhotoSize(size: PreviewSize)
   fun setPreviewSize(size: PreviewSize)
   fun setAspectRatio(aspectRatio: String)
-  fun setupImageAnalysisStream(format: String, width: Long)
+  fun setupImageAnalysisStream(format: String, width: Long, maxFramesPerSecond: Double?)
   fun setExifPreferences(exifPreferences: ExifPreferences)
 
   companion object {
@@ -632,7 +632,8 @@ val codec: MessageCodec<Any?> by lazy {
               val args = message as List<Any?>
               val formatArg = args[0] as String
               val widthArg = args[1].let { if (it is Int) it.toLong() else it as Long }
-              api.setupImageAnalysisStream(formatArg, widthArg)
+              val maxFramesPerSecondArg = args[2] as? Double
+              api.setupImageAnalysisStream(formatArg, widthArg, maxFramesPerSecondArg)
               wrapped["result"] = null
             } catch (exception: Error) {
               wrapped["error"] = wrapError(exception)

--- a/example/lib/ai_analysis_faces.dart
+++ b/example/lib/ai_analysis_faces.dart
@@ -78,8 +78,8 @@ class _CameraPageState extends State<CameraPage> {
     _analysisSubscription = _analysisImagesStream.stream
         // debounceTime does not work for some reasons so we use a workaround
         // .debounceTime(const Duration(milliseconds: 100))
-        .bufferTime(const Duration(milliseconds: 300))
-        .map((event) => event.isNotEmpty ? event.last : null)
+        // .bufferTime(const Duration(milliseconds: 300))
+        // .map((event) => event.isNotEmpty ? event.last : null)
         .listen((event) {
       if (event != null) {
         analyzeImage(event);
@@ -106,7 +106,8 @@ class _CameraPageState extends State<CameraPage> {
           },
           imageAnalysisConfig: AnalysisConfig(
             outputFormat: InputAnalysisImageFormat.nv21,
-            width: 512,
+            width: 250,
+            maxFramesPerSecond: 12,
           ),
           previewDecoratorBuilder: (state, previewSize, previewRect) {
             return IgnorePointer(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0-rc2"
+    version: "1.0.0-rc3"
   characters:
     dependency: transitive
     description:

--- a/ios/Classes/CameraPreview/CameraPreview.h
+++ b/ios/Classes/CameraPreview/CameraPreview.h
@@ -73,6 +73,7 @@ AVCaptureAudioDataOutputSampleBufferDelegate>
 - (void)setRecordingAudioMode:(bool)enableAudio;
 - (void)pauseVideoRecording;
 - (void)resumeVideoRecording;
+- (void)receivedImageFromStream;
 - (void)setAspectRatio:(AspectRatio)ratio;
 - (void)setExifPreferencesGPSLocation:(bool)gpsLocation;
 - (void)refresh;

--- a/ios/Classes/CameraPreview/CameraPreview.m
+++ b/ios/Classes/CameraPreview/CameraPreview.m
@@ -318,6 +318,10 @@
   }
 }
 
+- (void)receivedImageFromStream {
+  [self.imageStreamController receivedImageFromStream];
+}
+
 /// Get the first available camera on device (front or rear)
 - (NSString *)selectAvailableCamera:(CameraSensor)sensor {
   if (_captureDeviceId != nil) {

--- a/ios/Classes/CamerawesomePlugin.m
+++ b/ios/Classes/CamerawesomePlugin.m
@@ -141,6 +141,8 @@ FlutterEventSink imageStreamEventSink;
     [self _handleSetExifPreferences:call result:result];
   } else if ([@"setupAnalysis" isEqualToString:call.method]) {
     [self _handleSetupAnalysis:call result:result];
+  } else if ([@"receivedImageFromStream" isEqualToString:call.method]) {
+    [self _handleReceivedImageFromStream:call result:result];
   } else if ([@"getSensors" isEqualToString:call.method]) {
     [self _handleGetSensors:call result:result];
   } else if ([@"dispose" isEqualToString:call.method]) {
@@ -176,6 +178,10 @@ FlutterEventSink imageStreamEventSink;
   [self.camera pauseVideoRecording];
 }
 
+- (void)_handleReceivedImageFromStream:(FlutterMethodCall*)call result:(FlutterResult)result {
+  [self.camera receivedImageFromStream];
+}
+
 - (void)_handleResumeVideoRecording:(FlutterMethodCall*)call result:(FlutterResult)result {
   [self.camera resumeVideoRecording];
 }
@@ -186,8 +192,14 @@ FlutterEventSink imageStreamEventSink;
 }
 
 - (void)_handleSetupAnalysis:(FlutterMethodCall*)call result:(FlutterResult)result {
+  float maxFramesPerSecond = [call.arguments[@"maxFramesPerSecond"] floatValue];
+  
   // Force low preview resolution
   [_camera setPreviewSize:CGSizeMake(720, 1280)];
+  
+  // Force a frame rate to improve performance
+  [_camera.imageStreamController setMaxFramesPerSecond:maxFramesPerSecond];
+  
   result(nil);
 }
 
@@ -266,7 +278,6 @@ FlutterEventSink imageStreamEventSink;
   }
   
   CameraSensor sensor = ([sensorName isEqualToString:@"FRONT"]) ? Front : Back;
-  
   [_camera setSensor:sensor deviceId:captureDeviceId];
   
   result(nil);

--- a/ios/Classes/CamerawesomePlugin.m
+++ b/ios/Classes/CamerawesomePlugin.m
@@ -139,6 +139,8 @@ FlutterEventSink imageStreamEventSink;
     [self _handleGetMaxZoom:call result:result];
   } else if ([@"setExifPreferences" isEqualToString:call.method]) {
     [self _handleSetExifPreferences:call result:result];
+  } else if ([@"setupAnalysis" isEqualToString:call.method]) {
+    [self _handleSetupAnalysis:call result:result];
   } else if ([@"getSensors" isEqualToString:call.method]) {
     [self _handleGetSensors:call result:result];
   } else if ([@"dispose" isEqualToString:call.method]) {
@@ -181,6 +183,12 @@ FlutterEventSink imageStreamEventSink;
 - (void)_handleRecordingAudioMode:(FlutterMethodCall*)call result:(FlutterResult)result {
   bool value = [call.arguments[@"enableAudio"] boolValue];
   [_camera setRecordingAudioMode:value];
+}
+
+- (void)_handleSetupAnalysis:(FlutterMethodCall*)call result:(FlutterResult)result {
+  // Force low preview resolution
+  [_camera setPreviewSize:CGSizeMake(720, 1280)];
+  result(nil);
 }
 
 - (void)_handleGetSensors:(FlutterMethodCall*)call result:(FlutterResult)result {
@@ -229,6 +237,11 @@ FlutterEventSink imageStreamEventSink;
 }
 
 - (void)_handleRecordVideo:(FlutterMethodCall*)call result:(FlutterResult)result {
+  if (_camera.imageStreamController.streamImages == true) {
+    result([FlutterError errorWithCode:@"STREAM_IN_PROGRESS" message:@"camera stream is in progress, please stop streaming before" details:nil]);
+    return;
+  }
+  
   NSString *path = call.arguments[@"path"];
   NSDictionary *options = call.arguments[@"options"];
   

--- a/ios/Classes/Controllers/ImageStream/ImageStreamController.h
+++ b/ios/Classes/Controllers/ImageStream/ImageStreamController.h
@@ -15,12 +15,18 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ImageStreamController : NSObject
 
 @property(readonly, nonatomic) bool streamImages;
+@property(readonly, nonatomic) float maxFramesPerSecond;
+@property(readonly, nonatomic) NSDate *latestEmittedFrame;
 @property(nonatomic) FlutterEventSink imageStreamEventSink;
+
+@property(readonly, nonatomic) NSInteger processingImage;
 
 - (instancetype)initWithStreamImages:(bool)streamImages;
 - (void)captureOutput:(AVCaptureOutput *)output didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer fromConnection:(AVCaptureConnection *)connection orientation:(UIDeviceOrientation)orientation;
 - (void)setImageStreamEventSink:(FlutterEventSink)imageStreamEventSink;
 - (void)setStreamImages:(bool)streamImages;
+- (void)receivedImageFromStream;
+- (void)setMaxFramesPerSecond:(float)maxFramesPerSecond;
 
 @end
 

--- a/ios/Classes/Utils/CameraQualities.m
+++ b/ios/Classes/Utils/CameraQualities.m
@@ -32,8 +32,6 @@
     return CGSizeMake(1920, 1080);
   } else if (presset == AVCaptureSessionPreset1280x720) {
     return CGSizeMake(1280, 720);
-  } else if (presset == AVCaptureSessionPreset1280x720) {
-    return CGSizeMake(1280, 720);
   } else if (presset == AVCaptureSessionPreset640x480) {
     return CGSizeMake(640, 480);
   } else if (presset == AVCaptureSessionPreset352x288) {
@@ -61,19 +59,19 @@
 }
 
 + (NSString *)selectPresetForSize:(CGSize)size {
-  if (size.width >= 3840 && size.height >= 2160) {
+  if (size.width >= 2160 || size.height >= 3840) {
     if (@available(iOS 9.0, *)) {
       return AVCaptureSessionPreset3840x2160;
     } else {
       return AVCaptureSessionPreset1920x1080;
     }
-  } else if (size.width == 1920 && size.height == 1080) {
+  } else if (size.width == 1080 && size.height == 1920) {
     return AVCaptureSessionPreset1920x1080;
-  } else if (size.width == 1280 && size.height == 720) {
+  } else if (size.width == 720 && size.height == 1280) {
     return AVCaptureSessionPreset1280x720;
-  } else if (size.width == 640 && size.height == 480) {
+  } else if (size.width == 480 && size.height == 640) {
     return AVCaptureSessionPreset640x480;
-  } else if (size.width == 352 && size.height == 288) {
+  } else if (size.width == 288 && size.height == 352) {
     return AVCaptureSessionPreset352x288;
   } else {
     // Default to HD

--- a/lib/camerawesome_plugin.dart
+++ b/lib/camerawesome_plugin.dart
@@ -137,10 +137,9 @@ class CamerawesomePlugin {
     return _permissionsStream;
   }
 
-  /// this is not needed on iOS
   static Future<void> setupAnalysis({
     int width = 0,
-    num maxFramesPerSecond = 0,
+    num? maxFramesPerSecond,
     required InputAnalysisImageFormat format,
   }) async {
     if (Platform.isAndroid) {
@@ -150,7 +149,7 @@ class CamerawesomePlugin {
       );
     } else {
       return _channel.invokeMethod("setupAnalysis", {
-        "maxFramesPerSecond": maxFramesPerSecond,
+        "maxFramesPerSecond": maxFramesPerSecond ?? 0,
       });
     }
   }

--- a/lib/camerawesome_plugin.dart
+++ b/lib/camerawesome_plugin.dart
@@ -147,6 +147,8 @@ class CamerawesomePlugin {
         format.name,
         width,
       );
+    } else {
+      return _channel.invokeMethod("setupAnalysis");
     }
   }
 

--- a/lib/camerawesome_plugin.dart
+++ b/lib/camerawesome_plugin.dart
@@ -140,6 +140,7 @@ class CamerawesomePlugin {
   /// this is not needed on iOS
   static Future<void> setupAnalysis({
     int width = 0,
+    num maxFramesPerSecond = 0,
     required InputAnalysisImageFormat format,
   }) async {
     if (Platform.isAndroid) {
@@ -148,7 +149,9 @@ class CamerawesomePlugin {
         width,
       );
     } else {
-      return _channel.invokeMethod("setupAnalysis");
+      return _channel.invokeMethod("setupAnalysis", {
+        "maxFramesPerSecond": maxFramesPerSecond,
+      });
     }
   }
 
@@ -159,11 +162,20 @@ class CamerawesomePlugin {
         StreamTransformer<dynamic, Map<String, dynamic>>.fromHandlers(
           handleData: (data, sink) {
             sink.add(Map<String, dynamic>.from(data));
+            CamerawesomePlugin.receivedImageFromStream();
           },
         ),
       );
     }
     return _imagesStream;
+  }
+
+  static Future receivedImageFromStream() {
+    if (Platform.isIOS) {
+      return _channel.invokeMethod("receivedImageFromStream");
+    } else {
+      return Future.value();
+    }
   }
 
   static Future<bool?> init(SensorConfig sensorConfig, bool enableImageStream,
@@ -291,7 +303,10 @@ class CamerawesomePlugin {
   }
 
   // TODO: add video options for Android
-  static recordVideo(String path, {CupertinoVideoOptions? cupertinoVideoOptions,}) {
+  static recordVideo(
+    String path, {
+    CupertinoVideoOptions? cupertinoVideoOptions,
+  }) {
     if (Platform.isAndroid) {
       return CameraInterface().recordVideo(path);
     } else {

--- a/lib/camerawesome_plugin.dart
+++ b/lib/camerawesome_plugin.dart
@@ -139,13 +139,14 @@ class CamerawesomePlugin {
 
   static Future<void> setupAnalysis({
     int width = 0,
-    num? maxFramesPerSecond,
+    double? maxFramesPerSecond,
     required InputAnalysisImageFormat format,
   }) async {
     if (Platform.isAndroid) {
       return CameraInterface().setupImageAnalysisStream(
         format.name,
         width,
+        maxFramesPerSecond,
       );
     } else {
       return _channel.invokeMethod("setupAnalysis", {
@@ -226,7 +227,6 @@ class CamerawesomePlugin {
   }
 
   static Future<num?> getPreviewTexture() {
-    // TODO Provide a different texture for front and back camera, so we can get a preview for both?
     if (Platform.isAndroid) {
       return CameraInterface().getPreviewTextureId();
     } else {
@@ -351,7 +351,6 @@ class CamerawesomePlugin {
     }
   }
 
-  /// TODO - Next step focus on a certain point
   static startAutoFocus() {
     if (Platform.isAndroid) {
       return CameraInterface().handleAutoFocus();

--- a/lib/pigeon.dart
+++ b/lib/pigeon.dart
@@ -70,7 +70,6 @@ class _CameraInterfaceCodec extends StandardMessageCodec {
       super.writeValue(buffer, value);
     }
   }
-
   @override
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
@@ -815,12 +814,13 @@ class CameraInterface {
   }
 
   Future<void> setupImageAnalysisStream(
-      String arg_format, int arg_width) async {
+      String arg_format, int arg_width, double? arg_maxFramesPerSecond) async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
         'dev.flutter.pigeon.CameraInterface.setupImageAnalysisStream', codec,
         binaryMessenger: _binaryMessenger);
     final Map<Object?, Object?>? replyMap = await channel
-        .send(<Object?>[arg_format, arg_width]) as Map<Object?, Object?>?;
+            .send(<Object?>[arg_format, arg_width, arg_maxFramesPerSecond])
+        as Map<Object?, Object?>?;
     if (replyMap == null) {
       throw PlatformException(
         code: 'channel-error',

--- a/lib/src/orchestrator/analysis/analysis_controller.dart
+++ b/lib/src/orchestrator/analysis/analysis_controller.dart
@@ -38,11 +38,10 @@ class AnalysisController {
       return;
     }
 
-    // TODO: is this very useful ?
-    // not needed for iOS
     await CamerawesomePlugin.setupAnalysis(
       format: conf.outputFormat,
       width: conf.width,
+      maxFramesPerSecond: conf.maxFramesPerSecond,
     );
 
     imageSubscription = _images$?.listen((event) {

--- a/lib/src/orchestrator/models/analysis_image.dart
+++ b/lib/src/orchestrator/models/analysis_image.dart
@@ -33,15 +33,13 @@ class AnalysisConfig {
   /// 
   /// For exemple, if the camera is producing 30fps and you set this to 10, it will skip 20 frames.
   /// 
-  /// Default is 0 (disabled).
-  /// 
-  /// Set it to 0 to disable.
-  final num maxFramesPerSecond;
+  /// Default is null (disabled).
+  final num? maxFramesPerSecond;
 
   AnalysisConfig({
     required this.outputFormat,
     required this.width,
-    this.maxFramesPerSecond = 0,
+    this.maxFramesPerSecond,
   });
 }
 

--- a/lib/src/orchestrator/models/analysis_image.dart
+++ b/lib/src/orchestrator/models/analysis_image.dart
@@ -30,11 +30,11 @@ class AnalysisConfig {
 
   /// This is used to improve performance on low performance devices.
   /// It will skip frames if the camera is producing more than the specified.
-  /// 
+  ///
   /// For exemple, if the camera is producing 30fps and you set this to 10, it will skip 20 frames.
-  /// 
+  ///
   /// Default is null (disabled).
-  final num? maxFramesPerSecond;
+  final double? maxFramesPerSecond;
 
   AnalysisConfig({
     required this.outputFormat,

--- a/lib/src/orchestrator/models/analysis_image.dart
+++ b/lib/src/orchestrator/models/analysis_image.dart
@@ -28,9 +28,20 @@ class AnalysisConfig {
   final InputAnalysisImageFormat outputFormat;
   final int width;
 
+  /// This is used to improve performance on low performance devices.
+  /// It will skip frames if the camera is producing more than the specified.
+  /// 
+  /// For exemple, if the camera is producing 30fps and you set this to 10, it will skip 20 frames.
+  /// 
+  /// Default is 0 (disabled).
+  /// 
+  /// Set it to 0 to disable.
+  final num maxFramesPerSecond;
+
   AnalysisConfig({
     required this.outputFormat,
     required this.width,
+    this.maxFramesPerSecond = 0,
   });
 }
 

--- a/pigeons/interface.dart
+++ b/pigeons/interface.dart
@@ -86,7 +86,11 @@ abstract class CameraInterface {
 
   void setAspectRatio(String aspectRatio);
 
-  void setupImageAnalysisStream(String format, int width);
+  void setupImageAnalysisStream(
+    String format,
+    int width,
+    double? maxFramesPerSecond,
+  );
 
   void setExifPreferences(ExifPreferences exifPreferences);
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -234,5 +234,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.17.3 <3.0.0"
   flutter: ">=3.0.0"


### PR DESCRIPTION
## Description

This is intended to fix all issues related to iOS stream images.
This adds 2 guards to improve performances & fix crashs on low performance devices.

- Add a system to emit **x** frames every second.
- Add a system to prevent overflow when too many frames are sent & not processed on Flutter part (useful on iPhone 6, 7 & lower for ex.).
- Force **HD** resolution on stream image mode (1280 x 720).

This PR fix #65

## Checklist

Before creating any Pull Request, confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] 📕 I read the [Contributing page](https://github.com/Apparence-io/camera_awesome/blob/master/CONTRIBUTING.md).
- [x] 🤝 I match the actual coding style.
- [x] ✅ I ran ```flutter analyze``` without any issues.

## Breaking Change

- [ ] 🛠 My feature contain breaking change.

*If your feature break something, please detail it*